### PR TITLE
fix: trigger webhook on publication state toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 	},
 	"peerDependencies": {
 		"@strapi/strapi": "^4.0.7",
-		"@strapi/helper-plugin": "^4.1.0",
+		"@strapi/utils": "^4.0.7",
+		"@strapi/helper-plugin": "^4.0.7",
 		"react-router-dom": "^6.2.1",
 		"react-query": "^3.34.16",
 		"react-intl": "^5.24.6",

--- a/server/services/emit-service.js
+++ b/server/services/emit-service.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const strapiUtils = require('@strapi/utils');
+const { ENTRY_PUBLISH, ENTRY_UNPUBLISH } = strapiUtils.webhook.webhookEvents;
+
+module.exports = ({ strapi }) => ({
+	async emit(event, uid, entity) {
+		const model = strapi.getModel(uid);
+		const sanitizedEntity = await strapiUtils.sanitize.sanitizers.defaultSanitizeOutput(
+			model,
+			entity
+		);
+
+		strapi.eventHub.emit(event, {
+			model: model.modelName,
+			entry: sanitizedEntity,
+		});
+	},
+
+	async publish(uid, entity) {
+		await this.emit(ENTRY_PUBLISH, uid, entity);
+	},
+
+	async unpublish(uid, entity) {
+		await this.emit(ENTRY_UNPUBLISH, uid, entity);
+	},
+});

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -1,9 +1,11 @@
 'use strict';
 
 const actionService = require('./action-service');
+const emitService = require('./emit-service');
 const publicationService = require('./publication-service');
 
 module.exports = {
 	actionService,
+	emitService,
 	publicationService,
 };

--- a/server/services/publication-service.js
+++ b/server/services/publication-service.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { getPluginService } = require('../utils/getPluginService');
 const { getPluginEntityUid } = require('../utils/getEntityUId');
 
 const actionUId = getPluginEntityUid('action');
@@ -9,24 +10,30 @@ module.exports = ({ strapi }) => ({
 	 * Publish a single record
 	 *
 	 */
-	publish(uid, entityId) {
-		return strapi.entityService.update(uid, entityId, {
+	async publish(uid, entityId) {
+		const publishedEntity = await strapi.entityService.update(uid, entityId, {
 			data: {
 				publishedAt: new Date(),
 			},
 		});
+
+		// emit publish event
+		await getPluginService(strapi, 'emitService').publish(uid, publishedEntity);
 	},
 
 	/**
-	 * Publish a single record
+	 * Unpublish a single record
 	 *
 	 */
-	unpublish(uid, entityId) {
-		return strapi.entityService.update(uid, entityId, {
+	async unpublish(uid, entityId) {
+		const unpublishedEntity = await strapi.entityService.update(uid, entityId, {
 			data: {
 				publishedAt: null,
 			},
 		});
+
+		// emit unpublish event
+		await getPluginService(strapi, 'emitService').unpublish(uid, unpublishedEntity);
 	},
 
 	/**


### PR DESCRIPTION
This fixes publish/unpublish webhooks not being triggered when entities publication states are changed.


### Related Issues(s)
 #10