### PR TITLE
use "default" variant for publish button

### DIFF
--- a/admin/src/components/Action/ActionFooter/index.js
+++ b/admin/src/components/Action/ActionFooter/index.js
@@ -63,7 +63,7 @@ const ActionFooter = ({
 
 	// add action
 	if (!isVisible) {
-		const addActionButtonColor = mode === 'publish' ? 'primary' : 'secondary';
+		const addActionButtonColor = mode === 'publish' ? 'default' : 'secondary';
 		const addActionButtonIcon = mode === 'publish' ? <Check /> : <Cross />;
 		return (
 			<Button


### PR DESCRIPTION
Another tiny fix: The "Add a publish date" uses the `primary` variant, but the variant is actually named `default`, according to here: https://design-system-git-main-strapijs.vercel.app/?path=/story/design-system-components-button--variants

This only prints a warning to the console when run in dev mode with the `--watch-admin` option, I assume because the warning is suppressed otherwise.

The button component appears to be falling back to the `default` variant in any case, so this doesn't affect how it actually gets rendered. The main effect is just to get rid of that warning in the console.