### PR TITLE
Copy webhook constants as they are removed

### DIFF
--- a/server/services/emit-service.js
+++ b/server/services/emit-service.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const strapiUtils = require('@strapi/utils');
-const { ENTRY_PUBLISH, ENTRY_UNPUBLISH } = strapiUtils.webhook.webhookEvents;
+
+const ENTRY_PUBLISH = 'entry.publish';
+const ENTRY_UNPUBLISH = 'entry.unpublish';
 
 module.exports = ({ strapi }) => ({
 	async emit(event, uid, entity) {


### PR DESCRIPTION
Moves constants for webhook events to this plugin as they have been removed by Strapi. Tested locally and seems to work just fine.

Fixes: https://github.com/ComfortablyCoding/strapi-plugin-publisher/issues/78
See https://github.com/strapi/strapi/issues/16955 for the issue