### PR TITLE
fix: date picker issue

### DIFF
--- a/admin/src/components/Action/ActionContent/index.js
+++ b/admin/src/components/Action/ActionContent/index.js
@@ -3,6 +3,16 @@ import PropTypes from 'prop-types';
 import { DateTimePicker } from '@strapi/helper-plugin';
 import { fetchSettings } from '../../../api/settings';
 
+export const parseDate = (date) => {
+	const timestamp = Date.parse(date);
+
+	if (Number.isNaN(timestamp) === false) {
+		return new Date(timestamp);
+	}
+
+	return null;
+};
+
 const ActionContent = ({ action, setAction, isDisabled }) => {
 	const [step, setStep] = useState(1);
 
@@ -32,7 +42,7 @@ const ActionContent = ({ action, setAction, isDisabled }) => {
 		<DateTimePicker
 			ariaLabel="datetime picker"
 			onChange={handleDateChange}
-			value={action.executeAt}
+			value={parseDate(action.executeAt)}
 			disabled={isDisabled}
 			step={step}
 		/>


### PR DESCRIPTION
It should fix issue with DatePicker crashing the page in https://github.com/ComfortablyCoding/strapi-plugin-publisher/issues/81 . Strapi moved and refactored DatePicker component and now it accepts only date instance and fails on strings. I've copied parseDate from their old codebase.