### PR TITLE
fix(actions): cannot delete or edit right after create

### DIFF
--- a/admin/src/components/Action/Action.js
+++ b/admin/src/components/Action/Action.js
@@ -87,12 +87,16 @@ const Action = ({ mode, entityId, entitySlug }) => {
 			}
 
 			if (!actionId) {
-				await createAction({
+				const { data: response } = await createAction({
 					mode,
 					entityId,
 					entitySlug,
 					executeAt,
 				});
+
+				if (response.data && response.data.id) {
+					setActionId(response.data.id);
+				}
 			} else {
 				await updateAction({ id: actionId, body: { executeAt } });
 			}


### PR DESCRIPTION
This PR fixes a bug where the user was unable to delete or edit the action right after creating it.