### PR TITLE
feat(dateTimePicker): allow user set locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,17 +65,18 @@ module.exports = ({ env }) => ({
 
 ### The Complete Plugin Configuration  Object
 
-| Property | Description | Type | Default | Required |
-| -------- | ----------- | ---- | ------- | -------- |
-| actions | Settings associated with any actions. | Object | {} | No |
-| actions.syncFrequency | The frequency to check for actions to run. It is a cron expression | String | '*/1 * * * *' | No |
-| components | Settings associated with any of the plugins components | Object | {} | No |
-| components.dateTimePicker | Settings associated with the DateTimePicker component used to set action times | Object | {} | No |
-| components.dateTimePicker.step | The step between the numbers displayed for the time section of the DateTimePicker | Number | 1 | No |
-| hooks.beforePublish | An async function that runs before a content type is published | Function | () => {} | No |
-| hooks.afterPublish | An async function that runs after a content type is published | Function | () => {} | No |
-| hooks.beforeUnpublish | An async function that runs before a content type is un-published | Function | () => {} | No |
-| hooks.afterUnpublish | An async function that runs after a content type is un-published | Function | () => {} | No |
+| Property                         | Description                                                                      | Type     | Default | Required |
+|----------------------------------|----------------------------------------------------------------------------------|----------| ------- | -------- |
+| actions                          | Settings associated with any actions.                                            | Object   | {} | No |
+| actions.syncFrequency            | The frequency to check for actions to run. It is a cron expression               | String   | '*/1 * * * *' | No |
+| components                       | Settings associated with any of the plugins components                           | Object   | {} | No |
+| components.dateTimePicker        | Settings associated with the DateTimePicker component used to set action times   | Object   | {} | No |
+| components.dateTimePicker.step   | The step between the numbers displayed for the time section of the DateTimePicker | Number   | 1 | No |
+| components.dateTimePicker.locale | Allows to enforce another locale to change the date layout                       | String   | '' | No |
+| hooks.beforePublish              | An async function that runs before a content type is published                   | Function | () => {} | No |
+| hooks.afterPublish               | An async function that runs after a content type is published                    | Function | () => {} | No |
+| hooks.beforeUnpublish            | An async function that runs before a content type is un-published                | Function | () => {} | No |
+| hooks.afterUnpublish             | An async function that runs after a content type is un-published                 | Function | () => {} | No |
 
 ### Enable server cron
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ module.exports = ({ env }) => ({
 | components                       | Settings associated with any of the plugins components                           | Object   | {} | No |
 | components.dateTimePicker        | Settings associated with the DateTimePicker component used to set action times   | Object   | {} | No |
 | components.dateTimePicker.step   | The step between the numbers displayed for the time section of the DateTimePicker | Number   | 1 | No |
-| components.dateTimePicker.locale | Allows to enforce another locale to change the date layout                       | String   | '' | No |
+| components.dateTimePicker.locale | Allows to enforce another locale to change the date layout                       | String   | browser locale | No |
 | hooks.beforePublish              | An async function that runs before a content type is published                   | Function | () => {} | No |
 | hooks.afterPublish               | An async function that runs after a content type is published                    | Function | () => {} | No |
 | hooks.beforeUnpublish            | An async function that runs before a content type is un-published                | Function | () => {} | No |

--- a/admin/src/components/Action/ActionDateTimePicker/ActionDateTimePicker.js
+++ b/admin/src/components/Action/ActionDateTimePicker/ActionDateTimePicker.js
@@ -11,7 +11,7 @@ import './ActionDateTimerPicker.css';
 
 const ActionDateTimePicker = ({ executeAt, mode, isCreating, isEditing, onChange }) => {
 	const [step, setStep] = useState(1);
-	const { formatMessage } = useIntl();
+	const { formatMessage, locale: browserLocale } = useIntl();
 	const { getSettings } = useSettings();
 
 	function handleDateChange(date) {
@@ -20,7 +20,22 @@ const ActionDateTimePicker = ({ executeAt, mode, isCreating, isEditing, onChange
 		}
 	}
 
+	function handleLocale(locale) {
+		if (!locale) {
+			return browserLocale;
+		} else {
+			try {
+				Intl.DateTimeFormat(locale);
+				return locale;
+			} catch (e) {
+				strapi.log.warn(`Given locale '${locale}' is not a valid locale, defaulting to browser locale which is: '${browserLocale}'`);
+				return browserLocale;
+			}
+		}
+	}
+
 	const { isLoading, data, isRefetching } = getSettings();
+	const locale = handleLocale(data.components.dateTimePicker.locale);
 
 	useEffect(() => {
 		if (!isLoading && !isRefetching) {
@@ -49,6 +64,7 @@ const ActionDateTimePicker = ({ executeAt, mode, isCreating, isEditing, onChange
 					value={executeAt ? new Date(executeAt) : null}
 					disabled={!isCreating}
 					step={step}
+					locale={locale}
 				/>
 			</Stack>
 		</div>

--- a/admin/src/components/Action/ActionDateTimePicker/ActionDateTimePicker.js
+++ b/admin/src/components/Action/ActionDateTimePicker/ActionDateTimePicker.js
@@ -10,8 +10,9 @@ import { useSettings } from '../../../hooks/useSettings';
 import './ActionDateTimerPicker.css';
 
 const ActionDateTimePicker = ({ executeAt, mode, isCreating, isEditing, onChange }) => {
-	const [step, setStep] = useState(1);
 	const { formatMessage, locale: browserLocale } = useIntl();
+	const [locale, setLocale] = useState(browserLocale);
+	const [step, setStep] = useState(1);
 	const { getSettings } = useSettings();
 
 	function handleDateChange(date) {
@@ -20,27 +21,22 @@ const ActionDateTimePicker = ({ executeAt, mode, isCreating, isEditing, onChange
 		}
 	}
 
-	function handleLocale(locale) {
-		if (!locale) {
-			return browserLocale;
-		} else {
-			try {
-				Intl.DateTimeFormat(locale);
-				return locale;
-			} catch (e) {
-				strapi.log.warn(`Given locale '${locale}' is not a valid locale, defaulting to browser locale which is: '${browserLocale}'`);
-				return browserLocale;
-			}
-		}
-	}
-
 	const { isLoading, data, isRefetching } = getSettings();
-	const locale = handleLocale(data.components.dateTimePicker.locale);
 
 	useEffect(() => {
 		if (!isLoading && !isRefetching) {
 			if (data) {
 				setStep(data.components.dateTimePicker.step);
+
+				const customLocale = data.components.dateTimePicker.locale;
+				try {
+					Intl.DateTimeFormat(customLocale);
+					setLocale(customLocale);
+				} catch (error) {
+					console.log(
+						`'${customLocale}' is not a valid format, using browser locale: '${browserLocale}'`
+					);
+				}
 			}
 		}
 	}, [isLoading, isRefetching]);


### PR DESCRIPTION
A feature PR to allows to enforce one locale if desired through the plugins options.
Also if the locale is faulty, like en_US instead of en-US then browser locale is used as a fallback 

Quick note:
Im not a react expert unfortunately, if anything is unorthodox or usually done in another way please leave a comment and I will try to fix it 😄 