### PR TITLE
feat: content type action display control

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ module.exports = ({ env }) => ({
 | hooks.afterPublish               | An async function that runs after a content type is published                    | Function | () => {} | No |
 | hooks.beforeUnpublish            | An async function that runs before a content type is un-published                | Function | () => {} | No |
 | hooks.afterUnpublish             | An async function that runs after a content type is un-published                 | Function | () => {} | No |
+| contentTypes                     | A list of content type uids where the publish actions should be displayed        | Array<String> | All content types | No |
 
 ### Enable server cron
 

--- a/admin/src/components/ActionManager/ActionManager.js
+++ b/admin/src/components/ActionManager/ActionManager.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 import { getTrad } from '../../utils/getTrad';
@@ -11,8 +11,8 @@ const actionModes = ['publish', 'unpublish'];
 const ActionManager = () => {
 	const { formatMessage } = useIntl();
 	const entity = useCMEditViewDataManager();
+	const [showActions, setShowActions] = useState(false);
 	const { getSettings } = useSettings();
-	const { data } = getSettings();
 
 	if (!entity.hasDraftAndPublish || entity.isCreatingEntry) {
 		return null;
@@ -22,7 +22,17 @@ const ActionManager = () => {
 		return null;
 	}
 
-	if(data && data.contentTypesToExclude && data.contentTypesToExclude[entity.slug]) {
+	const { isLoading, data, isRefetching } = getSettings();
+
+	useEffect(() => {
+		if (!isLoading && !isRefetching) {
+			if (!data.contentTypes?.length || data.contentTypes?.find((uid) => uid === entity.slug)) {
+				setShowActions(true);
+			}
+		}
+	}, [isLoading, isRefetching]);
+
+	if (!showActions) {
 		return null;
 	}
 

--- a/admin/src/components/ActionManager/ActionManager.js
+++ b/admin/src/components/ActionManager/ActionManager.js
@@ -4,18 +4,25 @@ import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 import { getTrad } from '../../utils/getTrad';
 import { Box, Stack, Typography, Divider } from '@strapi/design-system';
 import Action from '../Action';
+import { useSettings } from 'strapi-plugin-publisher/admin/src/hooks/useSettings';
 
 const actionModes = ['publish', 'unpublish'];
 
 const ActionManager = () => {
 	const { formatMessage } = useIntl();
 	const entity = useCMEditViewDataManager();
+	const { getSettings } = useSettings();
+	const { data } = getSettings();
 
 	if (!entity.hasDraftAndPublish || entity.isCreatingEntry) {
 		return null;
 	}
 
 	if (!entity.modifiedData?.id) {
+		return null;
+	}
+
+	if(data && data.contentTypesToExclude && data.contentTypesToExclude[entity.slug]) {
 		return null;
 	}
 

--- a/admin/src/components/ActionManager/ActionManager.js
+++ b/admin/src/components/ActionManager/ActionManager.js
@@ -4,7 +4,7 @@ import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 import { getTrad } from '../../utils/getTrad';
 import { Box, Stack, Typography, Divider } from '@strapi/design-system';
 import Action from '../Action';
-import { useSettings } from 'strapi-plugin-publisher/admin/src/hooks/useSettings';
+import { useSettings } from '../../hooks/useSettings';
 
 const actionModes = ['publish', 'unpublish'];
 

--- a/server/config/schema.js
+++ b/server/config/schema.js
@@ -20,6 +20,7 @@ const pluginConfigSchema = yup.object().shape({
 				.optional(),
 		})
 		.optional(),
+	contentTypes: yup.array().of(yup.string()).optional(),
 });
 
 module.exports = {


### PR DESCRIPTION
In order for the functionality to work, the developer has to add the following to config/plugins.js
#122 

```
  'publisher': {
	enabled: true,
	config: {
        	contentTypesToExclude: {
        	     "api::test-page.test-page": true,
      		}
	},
  },
```