### PR TITLE
fix: refactor ActionManager component to conform to react hooks rules

### DIFF
--- a/admin/src/components/ActionManager/ActionManager.js
+++ b/admin/src/components/ActionManager/ActionManager.js
@@ -50,7 +50,7 @@ const ActionManagerComponent = () => {
 			</Stack>
 		</Box>
 	);
-}
+};
 
 const ActionManager = () => {
 	const entity = useCMEditViewDataManager();

--- a/admin/src/components/ActionManager/ActionManager.js
+++ b/admin/src/components/ActionManager/ActionManager.js
@@ -8,20 +8,11 @@ import { useSettings } from '../../hooks/useSettings';
 
 const actionModes = ['publish', 'unpublish'];
 
-const ActionManager = () => {
+const ActionManagerComponent = () => {
 	const { formatMessage } = useIntl();
 	const entity = useCMEditViewDataManager();
 	const [showActions, setShowActions] = useState(false);
 	const { getSettings } = useSettings();
-
-	if (!entity.hasDraftAndPublish || entity.isCreatingEntry) {
-		return null;
-	}
-
-	if (!entity.modifiedData?.id) {
-		return null;
-	}
-
 	const { isLoading, data, isRefetching } = getSettings();
 
 	useEffect(() => {
@@ -59,6 +50,20 @@ const ActionManager = () => {
 			</Stack>
 		</Box>
 	);
+}
+
+const ActionManager = () => {
+	const entity = useCMEditViewDataManager();
+
+	if (!entity.hasDraftAndPublish || entity.isCreatingEntry) {
+		return null;
+	}
+
+	if (!entity.modifiedData?.id) {
+		return null;
+	}
+
+	return <ActionManagerComponent />;
 };
 
 export default ActionManager;


### PR DESCRIPTION
Closes #135.

This fixes the error: Rendered more hooks than during the previous render.