### PR TITLE
fix: fetch entity before publish or unpublish actions

### DIFF
--- a/server/services/publication-service.js
+++ b/server/services/publication-service.js
@@ -12,7 +12,10 @@ export default ({ strapi }) => ({
 		try {
 			const { hooks } = getPluginService('settingsService').get();
 
-			await hooks.beforePublish({ strapi, uid, entity: publishedEntity });
+			// Fetch the entity before publishing
+    	const entity = await strapi.entityService.findOne(uid, entityId, { locale });
+
+			await hooks.beforePublish({ strapi, uid, entity });
 
 			const publishedEntity = await strapi.documents(uid).publish({
 				documentId: entityId,
@@ -36,7 +39,10 @@ export default ({ strapi }) => ({
 		try {
 			const { hooks } = getPluginService('settingsService').get();
 
-			await hooks.beforeUnpublish({ strapi, uid, entity: unpublishedEntity });
+			// Fetch the entity before unpublishing
+			const entity = await strapi.entityService.findOne(uid, entityId, { locale });
+
+			await hooks.beforeUnpublish({ strapi, uid, entity });
 
 			const unpublishedEntity = await strapi.documents(uid).unpublish({
 				documentId: entityId,


### PR DESCRIPTION
Addresses https://github.com/pluginpal/strapi-plugin-publisher/issues/198

This PR provides the fix for the error which will occur after a publish or unpublish action, you can test this by publishing or unpublishing a document.